### PR TITLE
Changed Windows used Path to Process for func.exe

### DIFF
--- a/LogicAppUnit/Hosting/WorkflowTestHost.cs
+++ b/LogicAppUnit/Hosting/WorkflowTestHost.cs
@@ -220,7 +220,7 @@ namespace LogicAppUnit.Hosting
             // Handle the differences between platforms
             if (OperatingSystem.IsWindows())
             {
-                enviromentPath = Environment.GetEnvironmentVariable("PATH", EnvironmentVariableTarget.Machine);
+                enviromentPath = Environment.GetEnvironmentVariable("PATH", EnvironmentVariableTarget.Process);
                 exeName = "func.exe";
             }
             else


### PR DESCRIPTION
While implementing this framework into Azure DevOps pipelines using a self-hosted Windows and Microsoft hosted Windows  build agent, the "The enviroment variable PATH does not include the path for the 'func' executable." Exception was encountered. 
This was found to be due to line 223 of the WorkflowTestHost.cs file.

When pipeline tasks are run which prepend tools to Path (NodeTool, FuncToolsInstaller etc.), it appears the Process path is used resulting in the exception above when the check is against the machine Path in the code.

This change does not appear to impact local testing however rectifies issues with Azure DevOps pipelines.
