### PR TITLE
feat: Include the user environment variables path to the available pa…

### DIFF
--- a/LogicAppUnit/Hosting/WorkflowTestHost.cs
+++ b/LogicAppUnit/Hosting/WorkflowTestHost.cs
@@ -214,22 +214,22 @@ namespace LogicAppUnit.Hosting
         /// <exception cref="Exception">Thrown when the location of the 'func' executable could not be found.</exception>
         private static string GetEnvPathForFunctionTools()
         {
-            string enviromentPath;
+            string environmentPath;
             string exeName;
 
             // Handle the differences between platforms
             if (OperatingSystem.IsWindows())
             {
-                enviromentPath = Environment.GetEnvironmentVariable("PATH", EnvironmentVariableTarget.Machine);
+                environmentPath = $"{Environment.GetEnvironmentVariable("PATH", EnvironmentVariableTarget.Machine)};{Environment.GetEnvironmentVariable("PATH", EnvironmentVariableTarget.User)}";
                 exeName = "func.exe";
             }
             else
             {
-                enviromentPath = Environment.GetEnvironmentVariable("PATH");
+                environmentPath = Environment.GetEnvironmentVariable("PATH");
                 exeName = "func";
             }
 
-            string exePath = enviromentPath.Split(Path.PathSeparator).Select(x => Path.Combine(x, exeName)).Where(x => File.Exists(x)).FirstOrDefault();
+            string exePath = environmentPath.Split(Path.PathSeparator).Select(x => Path.Combine(x, exeName)).Where(x => File.Exists(x)).FirstOrDefault();
             if (!string.IsNullOrWhiteSpace(exePath))
             {
                 Console.WriteLine($"Path for Azure Function Core tools: {exePath}");


### PR DESCRIPTION
Some developers have not admin rights on the machines where they are developing. Therefore, we can only install the azure functions core tools in specific folders and then add that folder to the user environment path variable.
Therefore, we need that the path from the user is read also in order to get the path for the tools