### PR TITLE
Support for C# Inline Action

### DIFF
--- a/src/LogicAppUnit.Samples.LogicApps.Tests/Constants.cs
+++ b/src/LogicAppUnit.Samples.LogicApps.Tests/Constants.cs
@@ -14,6 +14,7 @@ namespace LogicAppUnit.Samples.LogicApps.Tests
         public static readonly string FLUENT_REQUEST_MATCHING_WORKFLOW = "fluent-workflow";
         public static readonly string HTTP_WORKFLOW = "http-workflow";
         public static readonly string HTTP_ASYNC_WORKFLOW = "http-async-workflow";
+        public static readonly string INLINE_SCRIPT_WORKFLOW = "inline-script-workflow";
         public static readonly string INVOKE_WORKFLOW = "invoke-workflow";
         public static readonly string LOOP_WORKFLOW = "loop-workflow";
         public static readonly string MANAGED_API_CONNECTOR_WORKFLOW = "managed-api-connector-workflow";

--- a/src/LogicAppUnit.Samples.LogicApps.Tests/InlineScriptWorkflow/InlineScriptWorkflowTest.cs
+++ b/src/LogicAppUnit.Samples.LogicApps.Tests/InlineScriptWorkflow/InlineScriptWorkflowTest.cs
@@ -1,0 +1,62 @@
+﻿using LogicAppUnit.Helper;
+using LogicAppUnit.Mocking;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+
+namespace LogicAppUnit.Samples.LogicApps.Tests.InlineScriptWorkflow
+{
+    /// <summary>
+    /// Test cases for the <i>http-workflow</i> workflow which uses a synchronous response for the HTTP trigger.
+    /// </summary>
+    [TestClass]
+    public class InlineScriptWorkflowTest : WorkflowTestBase
+    {
+        [TestInitialize]
+        public void TestInitialize()
+        {
+            Initialize(Constants.LOGIC_APP_TEST_EXAMPLE_BASE_PATH, Constants.INLINE_SCRIPT_WORKFLOW);
+        }
+
+        [ClassCleanup]
+        public static void CleanResources()
+        {
+            Close();
+        }
+
+        /// <summary>
+        /// Tests that the correct response is returned when the HTTP call to the Service Two API to update the customer details is successful.
+        /// </summary>
+        [TestMethod]
+        public void InlineScriptWorkflowTest_When_Successful()
+        {
+            using (ITestRunner testRunner = CreateTestRunner())
+            {
+                // Run the workflow
+                var workflowResponse = testRunner.TriggerWorkflow(
+                    GetRequest(),
+                    HttpMethod.Post);
+
+                // Check workflow run status
+                Assert.AreEqual(WorkflowRunStatus.Succeeded, testRunner.WorkflowRunStatus);
+
+                // Check action result
+                Assert.AreEqual(ActionStatus.Succeeded, testRunner.GetWorkflowActionStatus("Execute_CSharp_Script_Code"));
+                Assert.AreEqual(
+                    ContentHelper.FormatJson(ResourceHelper.GetAssemblyResourceAsString($"{GetType().Namespace}.MockData.Execute_CSharp_Script_Code_Output.json")),
+                    ContentHelper.FormatJson(testRunner.GetWorkflowActionOutput("Execute_CSharp_Script_Code").ToString()));
+            }
+        }
+
+        private static StringContent GetRequest()
+        {
+            return ContentHelper.CreateJsonStringContent(new {
+                name = "Jane"
+            });
+        }
+    }
+}

--- a/src/LogicAppUnit.Samples.LogicApps.Tests/InlineScriptWorkflow/MockData/Execute_CSharp_Script_Code_Output.json
+++ b/src/LogicAppUnit.Samples.LogicApps.Tests/InlineScriptWorkflow/MockData/Execute_CSharp_Script_Code_Output.json
@@ -1,0 +1,5 @@
+﻿{
+  "body": {
+    "message": "Hello Jane from CSharp action"
+  }
+}

--- a/src/LogicAppUnit.Samples.LogicApps.Tests/LogicAppUnit.Samples.LogicApps.Tests.csproj
+++ b/src/LogicAppUnit.Samples.LogicApps.Tests/LogicAppUnit.Samples.LogicApps.Tests.csproj
@@ -50,6 +50,7 @@
     <EmbeddedResource Include="FluentWorkflow\MockData\Response.json" />
     <EmbeddedResource Include="FluentWorkflow\MockData\Response.txt" />
     <EmbeddedResource Include="HttpWorkflow\MockData\SystemTwo_Request.json" />
+    <EmbeddedResource Include="InlineScriptWorkflow\MockData\Execute_CSharp_Script_Code_Output.json" />
     <EmbeddedResource Include="InvokeWorkflow\MockData\AddToPriorityQueueRequest.json" />
     <EmbeddedResource Include="InvokeWorkflow\MockData\InvokeWorkflowNotPriorityRequest.json" />
     <EmbeddedResource Include="InvokeWorkflow\MockData\InvokeWorkflowPriorityRequest.json" />

--- a/src/LogicAppUnit.Samples.LogicApps/inline-script-workflow/execute_csharp_script_code.csx
+++ b/src/LogicAppUnit.Samples.LogicApps/inline-script-workflow/execute_csharp_script_code.csx
@@ -1,0 +1,39 @@
+// Add the required libraries
+#r "Newtonsoft.Json"
+#r "Microsoft.Azure.Workflows.Scripting"
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Primitives;
+using Microsoft.Extensions.Logging;
+using Microsoft.Azure.Workflows.Scripting;
+using Newtonsoft.Json.Linq;
+
+/// <summary>
+/// Executes the inline csharp code.
+/// </summary>
+/// <param name="context">The workflow context.</param>
+/// <remarks> This is the entry-point to your code. The function signature should remain unchanged.</remarks>
+public static async Task<Results> Run(WorkflowContext context, ILogger log)
+{
+  var triggerOutputs = (await context.GetTriggerResults().ConfigureAwait(false)).Outputs;
+
+  ////the following dereferences the 'name' property from trigger payload.
+  var name = triggerOutputs?["body"]?["name"]?.ToString();
+
+  ////the following can be used to get the action outputs from a prior action
+  //var actionOutputs = (await context.GetActionResults("Compose").ConfigureAwait(false)).Outputs;
+
+  ////these logs will show-up in Application Insight traces table
+  //log.LogInformation("Outputting results.");
+
+  //var name = null;
+
+  return new Results
+  {
+    Message = !string.IsNullOrEmpty(name) ? $"Hello {name} from CSharp action" : "Hello from CSharp action."
+  };
+}
+
+public class Results
+{
+  public string Message {get; set;}
+}

--- a/src/LogicAppUnit.Samples.LogicApps/inline-script-workflow/workflow.json
+++ b/src/LogicAppUnit.Samples.LogicApps/inline-script-workflow/workflow.json
@@ -1,0 +1,34 @@
+{
+    "definition": {
+        "$schema": "https://schema.management.azure.com/providers/Microsoft.Logic/schemas/2016-06-01/workflowdefinition.json#",
+        "actions": {
+            "Execute_CSharp_Script_Code": {
+                "type": "CSharpScriptCode",
+                "inputs": {
+                    "CodeFile": "execute_csharp_script_code.csx"
+                },
+                "runAfter": {}
+            }
+        },
+        "contentVersion": "1.0.0.0",
+        "outputs": {},
+        "triggers": {
+            "manual": {
+                "type": "Request",
+                "kind": "Http",
+                "inputs": {
+                    "method": "POST",
+                    "schema": {
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            }
+                        },
+                        "type": "object"
+                    }
+                }
+            }
+        }
+    },
+    "kind": "Stateful"
+}

--- a/src/LogicAppUnit/CsxTestInput.cs
+++ b/src/LogicAppUnit/CsxTestInput.cs
@@ -1,0 +1,36 @@
+﻿namespace LogicAppUnit
+{
+    /// <summary>
+    /// Defines a C# script that is to be tested.
+    /// </summary>
+    public class CsxTestInput
+    {
+        /// <summary>
+        /// Gets the C# script content
+        /// </summary>
+        public string Script { init; get; }
+
+        /// <summary>
+        /// Gets the C# script relative path.
+        /// </summary>
+        public string RelativePath { init; get; }
+
+        /// <summary>
+        /// Gets the C# script filename.
+        /// </summary>
+        public string Filename { init; get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CsxTestInput"/> class.
+        /// </summary>
+        /// <param name="script">The script content.</param>
+        /// <param name="relativePath">The script relative path.</param>
+        /// <param name="filename">The script filename</param>
+        public CsxTestInput(string script, string relativePath, string filename)
+        {
+            this.Script = script;
+            this.RelativePath = relativePath;
+            this.Filename = filename;
+        }
+    }
+}

--- a/src/LogicAppUnit/TestRunner.cs
+++ b/src/LogicAppUnit/TestRunner.cs
@@ -149,6 +149,7 @@ namespace LogicAppUnit
         /// <param name="host">The contents of the host file.</param>
         /// <param name="parameters">The contents of the parameters file, or <c>null</c> if the file does not exist.</param>
         /// <param name="connections">The connections file, or <c>null</c> if the file does not exist.</param>
+        /// <param name="csxTestInputs">A collection of C# script files or <c>null</c> if there are none.</param>
         /// <param name="artifactsDirectory">The (optional) artifacts directory containing maps and schemas that are used by the workflow being tested.</param>
         /// <param name="customLibraryDirectory">The (optional) custom library (lib/custom) directory containing custom components that are used by the workflow being tested.</param>
         internal TestRunner(
@@ -157,8 +158,13 @@ namespace LogicAppUnit
             HttpClient client,
             List<MockResponse> mockResponsesFromBase,
             WorkflowDefinitionWrapper workflowDefinition,
-            LocalSettingsWrapper localSettings, string host, string parameters = null, ConnectionsWrapper connections = null,
-            DirectoryInfo artifactsDirectory = null, DirectoryInfo customLibraryDirectory = null)
+            LocalSettingsWrapper localSettings,
+            string host,
+            string parameters = null,
+            ConnectionsWrapper connections = null,
+            CsxTestInput[] csxTestInputs = null,
+            DirectoryInfo artifactsDirectory = null,
+            DirectoryInfo customLibraryDirectory = null)
         {
             if (loggingConfig == null)
                 throw new ArgumentNullException(nameof(loggingConfig));
@@ -185,7 +191,7 @@ namespace LogicAppUnit
 
             var workflowTestInput = new WorkflowTestInput[] { new WorkflowTestInput(workflowDefinition.WorkflowName, workflowDefinition.ToString()) };
             _workflowTestHost = new WorkflowTestHost(workflowTestInput, localSettings.ToString(), parameters, connections.ToString(), host,
-                                                        artifactsDirectory, customLibraryDirectory, loggingConfig.WriteFunctionRuntimeStartupLogs);
+                                                        csxTestInputs, artifactsDirectory, customLibraryDirectory, loggingConfig.WriteFunctionRuntimeStartupLogs);
             _apiHelper = new WorkflowApiHelper(client, workflowDefinition.WorkflowName);
 
             // Create the mock definition and mock HTTP host

--- a/src/LogicAppUnit/WorkflowTestBase.cs
+++ b/src/LogicAppUnit/WorkflowTestBase.cs
@@ -30,7 +30,7 @@ namespace LogicAppUnit
 
         private string _parameters;
         private string _host;
-
+        private CsxTestInput[] _csxTestInputs;
         private bool _workflowIsInitialised = false;
 
         #region Lifetime management
@@ -158,6 +158,11 @@ namespace LogicAppUnit
             _parameters = ReadFromPath(Path.Combine(logicAppBasePath, Constants.PARAMETERS), optional: true);
             _host = ReadFromPath(Path.Combine(logicAppBasePath, Constants.HOST));
 
+            _csxTestInputs = new DirectoryInfo(logicAppBasePath)
+                .GetFiles("*.csx", SearchOption.AllDirectories)
+                .Select(x => new CsxTestInput(File.ReadAllText(x.FullName), Path.GetRelativePath(logicAppBasePath, x.DirectoryName), x.Name))
+                .ToArray();
+
             // If this is a stateless workflow and the 'OperationOptions' is not 'WithStatelessRunHistory'...
             if (_workflowDefinition.WorkflowType == WorkflowType.Stateless && _localSettings.GetWorkflowOperationOptionsValue(_workflowDefinition.WorkflowName) != workflowOperationOptionsRunHistory)
             {
@@ -218,10 +223,18 @@ namespace LogicAppUnit
             }
 
             return new TestRunner(
-                _testConfig.Logging, _testConfig.Runner,
+                _testConfig.Logging,
+                _testConfig.Runner,
                 _client,
                 _mockResponses,
-                _workflowDefinition, _localSettings, _host, _parameters, _connections, _artifactDirectory, _customLibraryDirectory);
+                _workflowDefinition,
+                _localSettings,
+                _host,
+                _parameters,
+                _connections,
+                _csxTestInputs,
+                _artifactDirectory,
+                _customLibraryDirectory);
         }
 
         #endregion Create test runner


### PR DESCRIPTION
This adds support for the recently announced [C# Inline Action](https://techcommunity.microsoft.com/t5/azure-integration-services-blog/announcement-introducing-net-c-inline-action-for-azure-logic/ba-p/4160541). VS Code editor support is not there yet, however it's already possible to add csx files to the workflow by creating the files manually, where the name matches the action name.

The addition scans the logic app directory for any *.csx files and copies them to the working directory at the same relative paths. The reason for scanning the whole logic app directory is because it's possible to reuse code by importing *.csx files from locations outside of the workflow directory. Instead of trying to figure out which script imports which file this is the most straightforward solution.

The PR includes a test to verify the functionality.