### PR TITLE
Removed outputData that does not appear in func output

### DIFF
--- a/src/LogicAppUnit/Hosting/WorkflowTestHost.cs
+++ b/src/LogicAppUnit/Hosting/WorkflowTestHost.cs
@@ -117,7 +117,7 @@ namespace LogicAppUnit.Hosting
                         Console.WriteLine(outputData);
                     }
 
-                    if (outputData != null && outputData.Contains("Host started") && !processStarted.Task.IsCompleted)
+                    if (outputData != null && !processStarted.Task.IsCompleted)
                     {
                         processStarted.SetResult(true);
                     }


### PR DESCRIPTION
## Overview 
Currently the WorkflowTestHost does not start as it is awaiting output containing "Host started". After two minutes it times out and fails.

Fixing #37

## Changes
- WorkflowTestHost.cs
   - Removed the check for outputData containing "Host started" 


#### Example Output
_Note there is no "Host started" phrase._
```
 *  Executing task in folder net6.0: %userdata%\.azurelogicapps\dependencies\FuncCoreTools\func host start --verbose 


                  %%%%%%
                 %%%%%%
            @   %%%%%%    @
          @@   %%%%%%      @@
       @@@    %%%%%%%%%%%    @@@
     @@      %%%%%%%%%%        @@
       @@         %%%%       @@
         @@      %%%       @@
           @@    %%      @@
                %%
                %


Azure Functions Core Tools
Core Tools Version:       4.0.5455 Commit hash: N/A  (64-bit)
Function Runtime Version: 4.27.5.21554


Functions:

        Workflow1: serviceBusTrigger

        WorkflowDispatcher: edgeWorkflowRuntimeTrigger

[2024-09-14T10:47:28.843Z] Host lock lease acquired by instance ID '00000000000000000000000060E8719D'.

```
