### PR TITLE
Added functionality to specify managed api connections to Mock

### DIFF
--- a/src/LogicAppUnit/TestConfiguration.cs
+++ b/src/LogicAppUnit/TestConfiguration.cs
@@ -132,6 +132,13 @@ namespace LogicAppUnit
         /// </summary>
         public List<string> BuiltInConnectorsToMock { get; set; } = new List<string>();
 
+
+        /// <summary>
+        /// List of managed api connectors where the actions are to be replaced with HTTP actions referencing the test mock server.
+        /// </summary>
+        public List<string> ManagedApisToMock { get; set; } = new List<string>();
+
+
         /// <summary>
         /// <c>true</c> if the test framework automatically configures the <i>OperationOptions</i> setting to <i>WithStatelessRunHistory</i> for a stateless workflow, otherwise <c>false</c>.
         /// </summary>

--- a/src/LogicAppUnit/WorkflowTestBase.cs
+++ b/src/LogicAppUnit/WorkflowTestBase.cs
@@ -277,7 +277,7 @@ namespace LogicAppUnit
 
             _connections = new ConnectionsWrapper(ReadFromPath(Path.Combine(logicAppBasePath, Constants.CONNECTIONS), optional: true), _localSettings);
 
-            _connections.ReplaceManagedApiConnectionUrlsWithMockServer();
+            _connections.ReplaceManagedApiConnectionUrlsWithMockServer(_testConfig.Workflow.ManagedApisToMock);
 
             // The Functions runtime will not start if there are any Managed API connections using the 'ManagedServiceIdentity' authentication type
             // Check for this so that the test will fail early with a meaningful error message

--- a/src/LogicAppUnit/WorkflowTestBase.cs
+++ b/src/LogicAppUnit/WorkflowTestBase.cs
@@ -277,7 +277,7 @@ namespace LogicAppUnit
 
             _connections = new ConnectionsWrapper(ReadFromPath(Path.Combine(logicAppBasePath, Constants.CONNECTIONS), optional: true), _localSettings);
 
-            _connections.ReplaceManagedApiConnectionUrlsWithMockServer(_testConfig.Workflow.ManagedApisToMock);
+            _connections.ReplaceManagedApiConnectionUrlsWithMockServer(_testConfig.Workflow?.ManagedApisToMock);
 
             // The Functions runtime will not start if there are any Managed API connections using the 'ManagedServiceIdentity' authentication type
             // Check for this so that the test will fail early with a meaningful error message

--- a/src/LogicAppUnit/Wrapper/ConnectionsWrapper.cs
+++ b/src/LogicAppUnit/Wrapper/ConnectionsWrapper.cs
@@ -46,7 +46,7 @@ namespace LogicAppUnit.Wrapper
 
         /// <summary>
         /// Update the <i>connections</i> by replacing all URL references to managed API connectors with the URL reference for the mock test server.
-        ///         /// <param name="managedApisToMock">The list of managed API connections to mock, or <c>null</c> if the file does not exist.</param>
+        /// <param name="managedApisToMock">The list of managed API connections to mock, or <c>null</c> if the file does not exist.</param>
         /// </summary>
         
         public void ReplaceManagedApiConnectionUrlsWithMockServer(List<string> managedApisToMock)

--- a/src/LogicAppUnit/Wrapper/ConnectionsWrapper.cs
+++ b/src/LogicAppUnit/Wrapper/ConnectionsWrapper.cs
@@ -46,7 +46,9 @@ namespace LogicAppUnit.Wrapper
 
         /// <summary>
         /// Update the <i>connections</i> by replacing all URL references to managed API connectors with the URL reference for the mock test server.
+        ///         /// <param name="managedApisToMock">The list of managed API connections to mock, or <c>null</c> if the file does not exist.</param>
         /// </summary>
+        
         public void ReplaceManagedApiConnectionUrlsWithMockServer(List<string> managedApisToMock)
         {
             if (_jObjectConnection == null)

--- a/src/LogicAppUnit/Wrapper/ConnectionsWrapper.cs
+++ b/src/LogicAppUnit/Wrapper/ConnectionsWrapper.cs
@@ -52,10 +52,12 @@ namespace LogicAppUnit.Wrapper
             if (_jObjectConnection == null)
                 return;
 
-            var managedApiConnections = _jObjectConnection.SelectToken("managedApiConnections").Children<JProperty>()
-                                                            .Where(con => managedApisToMock
-                                                            .Contains(con.Name.ToString()))
-                                                            .ToList();
+            var managedApiConnections = _jObjectConnection.SelectToken("managedApiConnections").Children<JProperty>().ToList();
+
+            // If no managed apis are specified then all managed apis are mocked
+            if (managedApisToMock != null && managedApisToMock.Count > 0)
+                managedApiConnections = managedApiConnections.Where(con => managedApisToMock.Contains(con.Name)).ToList();
+
             if (managedApiConnections.Count > 0)
             {
                 Console.WriteLine("Updating connections file for managed API connectors:");

--- a/src/LogicAppUnit/Wrapper/ConnectionsWrapper.cs
+++ b/src/LogicAppUnit/Wrapper/ConnectionsWrapper.cs
@@ -47,12 +47,15 @@ namespace LogicAppUnit.Wrapper
         /// <summary>
         /// Update the <i>connections</i> by replacing all URL references to managed API connectors with the URL reference for the mock test server.
         /// </summary>
-        public void ReplaceManagedApiConnectionUrlsWithMockServer()
+        public void ReplaceManagedApiConnectionUrlsWithMockServer(List<string> managedApisToMock)
         {
             if (_jObjectConnection == null)
                 return;
 
-            var managedApiConnections = _jObjectConnection.SelectToken("managedApiConnections").Children<JProperty>().ToList();
+            var managedApiConnections = _jObjectConnection.SelectToken("managedApiConnections").Children<JProperty>()
+                                                            .Where(con => managedApisToMock
+                                                            .Contains(con.Name.ToString()))
+                                                            .ToList();
             if (managedApiConnections.Count > 0)
             {
                 Console.WriteLine("Updating connections file for managed API connectors:");


### PR DESCRIPTION
Added the functionality to choose which Managed APIs should be mocked.


To add a mock api, specify its connection name in the managedApisToMock property in the test properties: 

```json
{
    "logging": {
        "writeFunctionRuntimeStartupLogs": true,
        "WriteMockRequestMatchingLogs": true
    },
    "workflow": {
        "externalApiUrlsToMock": [],
        "builtInConnectorsToMock": [],
        "managedApisToMock": [
            "outlook"
        ]
    }
}

```